### PR TITLE
Composer updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ We recommend you to structure your templates in one of this ways:
 
 ## How to check php code style
 
-Check WP Code Style `vendor/bin/phpcs --standard=phpcs.ruleset.xml app/ -s`
+Check WP Code Style `composer cs`
 
 ## How to run static code analyzer
  
-Check PHPMD `vendor/bin/phpmd app text phpmd.ruleset.xml`
+Check PHPMD `composer md`
 
 ## Contribute
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "anrw/wp-scratch-theme",
+    "type": "Wordpress-theme",
     "description": "Wordpress Theme Boilerplate",
     "license": "GNU GPL",
     "authors": [
@@ -11,7 +12,8 @@
     "require": {
         "php": ">=5.6.0",
         "windwalker/renderer": "2.*",
-        "illuminate/view": "4.*"
+        "illuminate/view": "4.*",
+        "composer/installers": "^1.0"
     },
     "require-dev": {
         "wp-coding-standards/wpcs": "dev-master",
@@ -21,5 +23,9 @@
         "psr-4": {
             "Classy\\": "app/classes"
         }
+    },
+    "scripts": {
+        "cs": "phpcs --standard=phpcs.ruleset.xml app/ -s",
+        "md": "phpmd app text phpmd.ruleset.xml"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,111 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "29ac8d4c39321c9e2fbc289105dc8c35",
-    "content-hash": "59d3a6b6277cd49927ea7e82c4f52e8d",
+    "hash": "c33fa092814fc2bcaf5eafaf594614fd",
+    "content-hash": "52e6fe388ceea9f818d3297ed26e906c",
     "packages": [
+        {
+            "name": "composer/installers",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "a3595c5272a6f247228abb20076ed27321e4aae9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/a3595c5272a6f247228abb20076ed27321e4aae9",
+                "reference": "a3595c5272a6f247228abb20076ed27321e4aae9",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0"
+            },
+            "replace": {
+                "roundcube/plugin-installer": "*",
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.0.*@dev",
+                "phpunit/phpunit": "4.1.*"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "https://composer.github.io/installers/",
+            "keywords": [
+                "Craft",
+                "Dolibarr",
+                "Hurad",
+                "ImageCMS",
+                "MODX Evo",
+                "Mautic",
+                "OXID",
+                "RadPHP",
+                "SMF",
+                "Thelia",
+                "WolfCMS",
+                "agl",
+                "aimeos",
+                "annotatecms",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "elgg",
+                "expressionengine",
+                "fuelphp",
+                "grav",
+                "installer",
+                "joomla",
+                "kohana",
+                "laravel",
+                "lithium",
+                "magento",
+                "mako",
+                "mediawiki",
+                "modulework",
+                "moodle",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "puppet",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "symfony",
+                "typo3",
+                "wordpress",
+                "zend",
+                "zikula"
+            ],
+            "time": "2016-07-05 06:18:20"
+        },
         {
             "name": "illuminate/container",
             "version": "v4.2.17",
@@ -534,16 +636,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d"
+                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
-                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4edb770cb853def6e60c93abb088ad5ac2010c83",
+                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83",
                 "shasum": ""
             },
             "require": {
@@ -608,7 +710,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-05-30 22:24:32"
+            "time": "2016-07-13 23:29:13"
         },
         {
             "name": "symfony/config",
@@ -817,6 +919,8 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.6.0"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
I added `scripts` to composer.json so it is easier to run `phpcs` and `phpmd`.

Now you don't need to know the details of the command, you just run `composer cs` and `composer md`.

I also added `type` so that Composer installer will recognize the package as a theme.
