### PR TITLE
Fixes post get_content method and applies the_content filter

### DIFF
--- a/app/classes/models/post.php
+++ b/app/classes/models/post.php
@@ -295,7 +295,7 @@ class Post extends Basis {
 	 */
 	public function get_content( $page = 0 ) {
 		if ( 0 === absint( $page ) && $this->post_content ) {
-			return $this->post_content;
+			return apply_filters( 'the_content', $this->post_content );
 		}
 
 		$content = $this->post_content;


### PR DESCRIPTION
Initially `get_content` method returned  content with applied `the_content` filter only if `$post_content` property is empty. Now it applies `the_content` filter in any case. It fixes shortcodes execution.
