### PR TITLE
Updates get_request_hierarchy_list method

### DIFF
--- a/app/classes/hierarchy.php
+++ b/app/classes/hierarchy.php
@@ -241,6 +241,14 @@ class Hierarchy {
 
 		elseif ( 'front-page' === $type ) :
 
+			$template = self::get_classy_template();
+
+			if ( ! empty( $template ) ) {
+				$views[] = $template;
+				$views[] = 'page.' . $template;
+				$views[] = 'template.' . $template;
+			}
+
 			$views[] = 'front-page.front-page';
 			$views[] = 'front-page';
 


### PR DESCRIPTION
Fixes issue with a page that has classy template and is set as FrontPage in General->Reading settings. Initially it was ignored and custom template couldn't be found.
